### PR TITLE
Fix word card auto flip and assessment

### DIFF
--- a/src/app/components/guess-the-word/components/WordCard.tsx
+++ b/src/app/components/guess-the-word/components/WordCard.tsx
@@ -87,15 +87,28 @@ export const WordCard: React.FC = () => {
     }
   }, [state.currentWord]);
 
+  // Automatically flip the card when meanings become visible (timer ended)
+  useEffect(() => {
+    if (
+      state.meaningsVisible &&
+      !state.assessmentDone &&
+      pendingAssessment === null &&
+      !flipped
+    ) {
+      setFlipped(true);
+    }
+  }, [state.meaningsVisible, state.assessmentDone, pendingAssessment, flipped]);
+
   // Handler to trigger flip and then call assessment
   const handleAssessWithFlip = useCallback((knewIt: boolean) => {
     setPendingAssessment(knewIt);
-    setFlipped(true);
+    // Toggle the flip state so the card animates back to the front
+    setFlipped(prev => !prev);
   }, []);
 
   // After flip animation, call assessment and load next word
   useEffect(() => {
-    if (flipped && pendingAssessment !== null) {
+    if (pendingAssessment !== null) {
       const timeout = setTimeout(() => {
         finalAssessment(pendingAssessment);
         setFlipped(false); // reset for next word
@@ -103,7 +116,7 @@ export const WordCard: React.FC = () => {
       }, 500); // match the flip duration
       return () => clearTimeout(timeout);
     }
-  }, [flipped, pendingAssessment, finalAssessment]);
+  }, [pendingAssessment, finalAssessment]);
 
   if (state.isLoadingWord || !state.currentWord) {
     return <LoadingWordCard isLoadingWord={state.isLoadingWord} />;


### PR DESCRIPTION
### **User description**
## Summary
- auto-flip card when meanings show at timer end
- toggle flip when assessing so card returns to front
- trigger final assessment after flip animation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_683f62fb9fec83269ec96d11cd581c8a


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Automatically flip card when meanings become visible.

- Ensure card flips back to front before assessment.

- Trigger assessment after flip animation completes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WordCard.tsx</strong><dd><code>Improve card flip and assessment flow in WordCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/guess-the-word/components/WordCard.tsx

<li>Added effect to auto-flip card when meanings are shown.<br> <li> Modified assessment handler to toggle flip state for animation.<br> <li> Updated assessment logic to trigger after flip animation.<br> <li> Improved state handling for smoother card transitions.


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/piro-momo/pull/45/files#diff-6475ff9bd0323f77ea36f7ea54a7aa63bcbc69319e618215fec85ab77202eefc">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>